### PR TITLE
removed easter egg comment

### DIFF
--- a/EncoderController.py
+++ b/EncoderController.py
@@ -683,7 +683,7 @@ class EncoderController(MackieC4Component):
 
             # if a default Live device is chosen, iterate the DEVICE_DICT constant
             # to reorder the local list of plugin parameters
-            if self.__chosen_plugin.class_name in DEVICE_DICT.keys():  # MS should we import device dict from generic devices or Live?
+            if self.__chosen_plugin.class_name in DEVICE_DICT.keys():
                 device_banks = DEVICE_DICT[self.__chosen_plugin.class_name]
                 for bank in device_banks:
                     for param_name in bank:

--- a/EncoderController.py
+++ b/EncoderController.py
@@ -699,13 +699,14 @@ class EncoderController(MackieC4Component):
             else:
                 result = [(p, p.name) for p in self.__chosen_plugin.parameters]
 
-        self.__ordered_plugin_parameters = result  # MS This is were Jon logs the param names to the Live log
+        self.__ordered_plugin_parameters = result
         count = 0
         for p in self.__ordered_plugin_parameters:
+            # log the param names to the Live log in order
             self.main_script().log_message("Param {0} name <{1}>".format(count, p[1]))
             count += 1
 
-    def __reassign_encoder_parameters(self, for_display_only):  # MS "=False" after display only removed. Why?
+    def __reassign_encoder_parameters(self, for_display_only):  # JW see for_display_only discussion thread
         """ Reevaluate all v-pot parameter assignments """
         self.__filter_mst_trk = 0
         self.__filter_mst_trk_allow_audio = 0


### PR DESCRIPTION
This Pull request is simply to talk about this kind of thing.  I suspect a better collaborative flow would be to create Issues so we can talk to each other about the "issue" in a dedicated place rather than leaving easter-egg comments for each other directly in the code.  An approach I recommend would be to leave a TODO: comment that says something like "see issue #23" in the code, but then all "discussion" can occur against the Issue on the Issues tab, and then when agreement is reached the code either changes or not, and the TODO: can be removed, if not the entire comment.

I will go ahead and create an Issue about the DEVICE_DICT question.  You can approve or reject this Pull request, whatever you want to "try and see what happens".  At work, I always approve my own Pull requests, so I don't really know what happens when one is rejected.